### PR TITLE
Hack timezone support in

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,14 +229,14 @@
       </div>
     </div>
     <div class="days">
-      <div>Sun</div><div>Mon</div><div>Tues</div><div>Wed</div><div>Thurs</div><div>Fri</div><div>Sat</div>
+      <div></div><div></div><div></div><div></div><div></div><div></div><div></div>
     </div>
     <div class="calendar">
       <div></div><div></div><div></div><div></div><div></div><div></div><div></div>
-      <div></div><div class="dev"></div><div class="dev"></div><div class="dev"></div><div class="dev"></div><div class="dev"></div><div></div>
-      <div></div><div class="ddt"></div><div class="ddt"></div><div class="ddt"></div><div class="ddt"></div><div class="ddt"></div><div></div>
-      <div></div><div class="qa" ></div><div class="qa" ></div><div class="qa" ></div><div class="qa" ></div><div class="qa" ></div><div></div>
-      <div></div><div class="qa" ></div><div class="qa" ></div><div></div><div></div><div></div><div></div>
+      <div></div><div></div><div></div><div></div><div></div><div></div><div></div>
+      <div></div><div></div><div></div><div></div><div></div><div></div><div></div>
+      <div></div><div></div><div></div><div></div><div></div><div></div><div></div>
+      <div></div><div></div><div></div><div></div><div></div><div></div><div></div>
       <div></div><div></div><div></div><div></div><div></div><div></div><div></div>
     </div>
   </div>

--- a/js/cal.js
+++ b/js/cal.js
@@ -1,16 +1,37 @@
+var timezone = 'T12:00:00 -0800';
+
 var Calendar = {
   // render the calendar given the specified train
   render: function(selector, train) {
-    train = train.replace(/\./g, '/');
+    train = train.replace(/\./g, '-') + timezone;
     // first update the visual calendar
     var m = moment(train).subtract('days', 19);
     var kids = $(".calendar > div");
     kids.removeClass('today');
+    var calendarDay = 1;
     for (var i = 0; i < kids.length; i++) {
       $(kids[i]).text(m.format("MM/DD"));
       if (m.sod().diff(moment().sod()) === 0) {
         $(kids[i]).addClass("today").text("today");
       }
+      else if (calendarDay < 32) {
+        if (calendarDay > 21 && m.day() > 0 && m.day() < 6) {
+          $(kids[i]).addClass("qa");
+        }
+        else if (calendarDay > 14 && m.day() > 0 && m.day() < 6) {
+          $(kids[i]).addClass("ddt");
+        }
+        else if (calendarDay > 7 && m.day() > 0 && m.day() < 6) {
+          $(kids[i]).addClass("dev");
+        }
+      }
+      m.add('days', 1);
+      calendarDay += 1;
+    }
+    var m = moment(train).subtract('days', 19);
+    var kids = $(".days > div");
+    for (var i = 0; i < kids.length; i++) {
+      $(kids[i]).text(m.format("ddd"));
       m.add('days', 1);
     }
 

--- a/js/main.js
+++ b/js/main.js
@@ -16,7 +16,7 @@ function whatTrain(fromWhen) {
 $(function($){
   // determine what train we're talking about
   function setTrain(train) {
-    var m = moment(train.replace(/\./g, '/'));
+    var m = moment(train.replace(/\./g, '-') + timezone);
     $(".train .name .name").text(train);
     $(".train .branches").text(m.eod().fromNow());
     $(".train .ships").text(m.add("days", 12).fromNow());


### PR DESCRIPTION
Explicitly set the Pacific timezone on the various dates and then
hack the calendar display to show the right day of the week.

This hack has the side effect of starting the week on Monday for
those of us that live on the left side of the International Date
Line. A nice bonus :)

![timezone-support](https://f.cloud.github.com/assets/167821/138578/eb069118-71b4-11e2-91f8-d88ed4295d14.png)
