### PR TITLE
Move Github ribbon to left side

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,7 +212,7 @@
     </div>
   </div>
 </section>
-<a href="https://github.com/lloyd/personatra.in"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork personatra.in on GitHub"></a>
+<a href="https://github.com/lloyd/personatra.in"><img style="position: absolute; top: 0; left: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_left_darkblue_121621.png" alt="Fork personatra.in on GitHub"></a>
 </body>
 <script src="js/zepto.min.js"></script>
 <script src="js/moment.min.js"></script>


### PR DESCRIPTION
I always accidentally click the ribbon when I want to see the schedule for the next train--this happens with most screen widths. Also happens on mobile.
